### PR TITLE
Update dependencies and enable stack build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.stack-work

--- a/bson-generic.cabal
+++ b/bson-generic.cabal
@@ -19,10 +19,10 @@ library
       Data.Bson.Generic
 
   build-depends:
-      base     == 4.6.*
-    , bson     == 0.2.*
-    , ghc-prim == 0.3.*
-    , text     == 0.11.*
+      base     == 4.8.*
+    , bson     == 0.3.*
+    , ghc-prim == 0.4.*
+    , text     == 1.2.1.*
 
   ghc-options: -O2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,5 @@
+flags: {}
+packages:
+- '.'
+extra-deps: []
+resolver: lts-3.4


### PR DESCRIPTION
As ```bson-generic``` not on stackage yet, I wanted to use it as a local package but run into issues with old dependencies. I've updated them and added a stack.yml file.