### PR TITLE
Updated to build for Stackage lts-7.2

### DIFF
--- a/bson-generic.cabal
+++ b/bson-generic.cabal
@@ -19,10 +19,10 @@ library
       Data.Bson.Generic
 
   build-depends:
-      base     == 4.8.*
-    , bson     == 0.3.*
-    , ghc-prim == 0.4.*
-    , text     == 1.2.1.*
+      base     >= 4.8 && < 5
+    , bson     >= 0.3 && < 0.4
+    , ghc-prim >= 0.4 && < 0.6
+    , text     >= 1.2.1 && < 1.3
 
   ghc-options: -O2
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 packages:
 - '.'
 extra-deps: []
-resolver: lts-3.4
+resolver: lts-7.2


### PR DESCRIPTION
Part of this was making the cabal build-depends bounds a little
wider.